### PR TITLE
Potential fix for code scanning alert no. 10: Default version of SSL/TLS may be insecure

### DIFF
--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -134,7 +134,7 @@ try:
 except ImportError:
 
     class SSLContext(object):  # Platform-specific: Python 2
-        def __init__(self, protocol_version):
+        def __init__(self, protocol_version=ssl.PROTOCOL_TLSv1_2):
             self.protocol = protocol_version
             # Use default values from a real SSLContext
             self.check_hostname = False
@@ -176,7 +176,7 @@ except ImportError:
                 "certfile": self.certfile,
                 "ca_certs": self.ca_certs,
                 "cert_reqs": self.verify_mode,
-                "ssl_version": self.protocol,
+                "ssl_version": self.protocol or ssl.PROTOCOL_TLSv1_2,
                 "server_side": server_side,
             }
             return wrap_socket(socket, ciphers=self.ciphers, **kwargs)


### PR DESCRIPTION
Potential fix for [https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/10](https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/10)

To fix the issue, we need to ensure that a secure protocol version (e.g., `ssl.PROTOCOL_TLSv1_2` or higher) is explicitly specified when calling `ssl.wrap_socket`. This can be achieved by modifying the `wrap_socket` method in the `SSLContext` class to include a secure protocol version in the `kwargs` dictionary. Additionally, we should update the `__init__` method of the `SSLContext` class to default to a secure protocol version if none is provided.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
