### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/voice-ci.yml
+++ b/.github/workflows/voice-ci.yml
@@ -1,4 +1,6 @@
 name: Voice Assistant CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/1](https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/1)

To fix the problem, add a `permissions` key to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and installs dependencies, it only needs read access to repository contents. The best way to do this is to add `permissions: { contents: read }` at the top level of the workflow file, just below the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
