### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/botocore/utils.py
+++ b/botocore/utils.py
@@ -1781,7 +1781,8 @@ class S3EndpointSetter(object):
 
         # Accelerate is only valid for Amazon endpoints.
         netloc = urlsplit(self._endpoint_url).netloc
-        if not netloc.endswith('amazonaws.com'):
+        # Ensure netloc is exactly 'amazonaws.com' or a subdomain of it
+        if not (netloc == 'amazonaws.com' or netloc.endswith('.amazonaws.com')):
             return False
 
         # The first part of the url should always be s3-accelerate.


### PR DESCRIPTION
Potential fix for [https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/2](https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/2)

To fix this problem, we need to ensure that the `netloc` is either exactly `amazonaws.com` or a subdomain of `amazonaws.com` (e.g., `s3-accelerate.amazonaws.com`, `foo.s3-accelerate.amazonaws.com`, etc.), but not something like `malicious-amazonaws.com` or `amazonaws.com.evil.com`. The best way to do this is to check that the `netloc` is either equal to `amazonaws.com` or ends with `.amazonaws.com`. This ensures that only the correct domain and its subdomains are accepted.

The change should be made in the `_use_accelerate_endpoint` method, specifically at the check on line 1784. No new imports are needed, as string methods suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
