### PR TITLE
Potential fix for code scanning alert no. 7: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/botocore/credentials.py
+++ b/botocore/credentials.py
@@ -21,7 +21,7 @@ import json
 import subprocess
 from collections import namedtuple
 from copy import deepcopy
-from hashlib import sha1
+from hashlib import sha256
 
 from dateutil.parser import parse
 from dateutil.tz import tzlocal, tzutc
@@ -2017,7 +2017,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         # pass separators resulting in non-minified JSON. In the long term,
         # all fetchers should use the below caching scheme.
         args = json.dumps(args, sort_keys=True, separators=(',', ':'))
-        argument_hash = sha1(args.encode('utf-8')).hexdigest()
+        argument_hash = sha256(args.encode('utf-8')).hexdigest()
         return self._make_file_safe(argument_hash)
 
     def _parse_timestamp(self, timestamp_ms):


### PR DESCRIPTION
Potential fix for [https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/7](https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/7)

To fix the problem, replace the use of SHA-1 with a strong cryptographic hash function, such as SHA-256, when generating the cache key in `SSOCredentialFetcher._create_cache_key`. This involves changing the import from `from hashlib import sha1` to `from hashlib import sha256`, and updating the code to use `sha256(args.encode('utf-8')).hexdigest()` instead of `sha1(...)`. Only lines related to the hash function need to be changed; the rest of the logic remains the same. Ensure the import is updated at the top of the file, and the hash function is replaced in the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
