### PR TITLE
Potential fix for code scanning alert no. 11: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -142,6 +142,12 @@ class HTTPDigestAuth(AuthBase):
             _algorithm = algorithm.upper()
         # lambdas assume digest modules are imported at the top level
         if _algorithm == 'MD5' or _algorithm == 'MD5-SESS':
+            warnings.warn(
+                "Insecure hash algorithm (MD5) used for HTTP Digest Authentication. "
+                "MD5 is considered cryptographically broken and should be avoided. "
+                "If possible, use a server that supports a stronger algorithm such as SHA-256 or SHA-512.",
+                UserWarning
+            )
             def md5_utf8(x):
                 if isinstance(x, str):
                     x = x.encode('utf-8')


### PR DESCRIPTION
Potential fix for [https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/11](https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/11)

To fix the problem, we should avoid using MD5 for hashing sensitive data such as passwords. Instead, we should use a strong, modern cryptographic hash function such as SHA-256 or SHA-512. In the context of HTTP Digest Authentication, the algorithm is determined by the server's challenge, so we cannot unilaterally change it to SHA-256 or SHA-512. However, we can improve the code by warning the user when MD5 is used, and by preferring stronger algorithms when possible. If the server requests MD5, we must use it for compatibility, but we should make it clear to the user that this is insecure.

Specifically, in `requests/auth.py`, in the block where the hash function is selected based on the algorithm, we should:
- Add a warning when MD5 or MD5-SESS is used, informing the user that this is insecure.
- Optionally, document that stronger algorithms are preferred and that MD5 is only used for compatibility.

No new imports are needed, as `warnings` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
