### PR TITLE
Potential fix for code scanning alert no. 11: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -154,13 +154,17 @@ class HTTPDigestAuth(AuthBase):
                 return hashlib.md5(x).hexdigest()
             hash_utf8 = md5_utf8
         elif _algorithm == 'SHA':
-            from argon2 import PasswordHasher
-            ph = PasswordHasher()
-            def argon2_utf8(x):
+            warnings.warn(
+                "Insecure hash algorithm (SHA-1) used for HTTP Digest Authentication. "
+                "SHA-1 is considered weak and should be avoided. "
+                "If possible, use a server that supports a stronger algorithm such as SHA-256 or SHA-512.",
+                UserWarning
+            )
+            def sha1_utf8(x):
                 if isinstance(x, str):
                     x = x.encode('utf-8')
-                return ph.hash(x)
-            hash_utf8 = argon2_utf8
+                return hashlib.sha1(x).hexdigest()
+            hash_utf8 = sha1_utf8
         elif _algorithm == 'SHA-256':
             def sha256_utf8(x):
                 if isinstance(x, str):


### PR DESCRIPTION
Potential fix for [https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/11](https://github.com/timothygwebb/roku-voice-assistant/security/code-scanning/11)

To fix the problem, the code should avoid using MD5 for hashing sensitive data unless it is strictly required by the server (i.e., the server only supports MD5). The code already supports SHA-256 and SHA-512, so the fix should ensure that these are preferred, and MD5 is only used as a last resort. Additionally, the code should not suggest using Argon2 for HTTP Digest Authentication, as Argon2 is not compatible with the protocol and would break interoperability.

**Detailed fix:**  
- Remove the use of Argon2 for the 'SHA' algorithm, as this is not a valid digest algorithm for HTTP Digest Authentication.
- For 'MD5' and 'MD5-SESS', keep the warning, but make it clear that MD5 is only used because the server requires it.
- For 'SHA', use SHA-1 (as per RFC 7616), but emit a warning that SHA-1 is also considered weak and should be avoided.
- For 'SHA-256' and 'SHA-512', use the corresponding hashlib functions.
- Do not introduce password hashing algorithms (like Argon2) into HTTP Digest Authentication, as this would break protocol compliance.

**Required changes:**  
- Remove the import and use of Argon2.
- Use `hashlib.sha1` for 'SHA' (with a warning).
- Ensure only hashlib is used for digest algorithms.
- No new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
